### PR TITLE
docs: add README with TDD and event-driven setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# todo-vibe
+
+A clean, event-driven Todo application built with test-driven development (TDD). Commands trigger state changes and publish domain events.
+
+See [AGENTS.md](AGENTS.md) for collaboration guidelines and event-driven/TDD conventions.
+
+## Getting Started
+
+1. Install dependencies:
+
+   ```sh
+   npm install
+   ```
+
+2. Run tests:
+
+   ```sh
+   npm test
+   ```
+
+Once you're set up, use TDD to drive new features and model behavior with events.


### PR DESCRIPTION
## Summary
- add initial README describing event-driven todo app and TDD workflow
- link to AGENTS guidelines and outline basic install/test commands

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd194642188330b12f9f9d0afa34e5