### PR TITLE
Guard against empty titles when creating todos

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -1,0 +1,15 @@
+# Domain Events
+
+## TodoCreated
+
+Emitted when a todo is created.
+
+### Data
+
+- `todoId`: string
+- `title`: string
+- `createdAt`: Date
+
+### Notes
+
+- `title` must be non-empty; `CreateTodo` throws an error if the title is blank.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A clean, event-driven Todo application built with test-driven development (TDD). Commands trigger state changes and publish domain events.
 
 See [AGENTS.md](AGENTS.md) for collaboration guidelines and event-driven/TDD conventions.
+Domain events are documented in [EVENTS.md](EVENTS.md).
 
 ## Getting Started
 

--- a/src/domain/todo/CreateTodo.spec.ts
+++ b/src/domain/todo/CreateTodo.spec.ts
@@ -5,8 +5,12 @@ const todoId = '1';
 const title = 'Test';
 const createdAt = new Date('2023-01-01T00:00:00Z');
 
-const result = CreateTodo({ todoId, title, createdAt });
+{
+  const result = CreateTodo({ todoId, title, createdAt });
 
-assert.deepStrictEqual(result, [
-  { type: 'TodoCreated', data: { todoId, title, createdAt } }
-]);
+  assert.deepStrictEqual(result, [
+    { type: 'TodoCreated', data: { todoId, title, createdAt } }
+  ]);
+}
+
+assert.throws(() => CreateTodo({ todoId, title: '', createdAt }), /title/i);

--- a/src/domain/todo/CreateTodo.ts
+++ b/src/domain/todo/CreateTodo.ts
@@ -1,3 +1,7 @@
 export function CreateTodo({ todoId, title, createdAt }: { todoId: string; title: string; createdAt: Date }) {
+  if (!title.trim()) {
+    throw new Error('title must be non-empty');
+  }
+
   return [{ type: 'TodoCreated', data: { todoId, title, createdAt } }];
 }


### PR DESCRIPTION
## Summary
- throw when CreateTodo receives an empty title
- cover empty-title scenario in CreateTodo.spec.ts
- document TodoCreated with title requirement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd214d1bb88330b5058dcfd9f4836d