### PR TITLE
feat(todo): add TodoCreated event type

### DIFF
--- a/src/domain/todo/CreateTodo.spec.ts
+++ b/src/domain/todo/CreateTodo.spec.ts
@@ -1,12 +1,13 @@
 import { strict as assert } from 'node:assert';
 import { CreateTodo } from './CreateTodo';
+import type { TodoCreated } from './events';
 
 const todoId = '1';
 const title = 'Test';
 const createdAt = new Date('2023-01-01T00:00:00Z');
 
 {
-  const result = CreateTodo({ todoId, title, createdAt });
+  const result: TodoCreated[] = CreateTodo({ todoId, title, createdAt });
 
   assert.deepStrictEqual(result, [
     { type: 'TodoCreated', data: { todoId, title, createdAt } }

--- a/src/domain/todo/CreateTodo.ts
+++ b/src/domain/todo/CreateTodo.ts
@@ -1,7 +1,10 @@
-export function CreateTodo({ todoId, title, createdAt }: { todoId: string; title: string; createdAt: Date }) {
+import type { TodoCreated } from './events';
+
+export function CreateTodo({ todoId, title, createdAt }: { todoId: string; title: string; createdAt: Date }): TodoCreated[] {
   if (!title.trim()) {
     throw new Error('title must be non-empty');
   }
 
-  return [{ type: 'TodoCreated', data: { todoId, title, createdAt } }];
+  const event: TodoCreated = { type: 'TodoCreated', data: { todoId, title, createdAt } };
+  return [event];
 }

--- a/src/domain/todo/events.ts
+++ b/src/domain/todo/events.ts
@@ -1,0 +1,10 @@
+export interface TodoCreated {
+  type: 'TodoCreated';
+  data: {
+    todoId: string;
+    title: string;
+    createdAt: Date;
+  };
+}
+
+export type TodoEvent = TodoCreated;


### PR DESCRIPTION
## Summary
- add `TodoCreated` event interface and export
- return typed `TodoCreated` from `CreateTodo`
- use `TodoCreated` type in `CreateTodo` tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd222032608330b72bdedf6ca4426e