### PR TITLE
feat: add introductory layout

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1,0 +1,18 @@
+.intro {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-family: system-ui, sans-serif;
+  background: linear-gradient(135deg, #f0f4ff, #d9e8ff);
+  color: #333;
+  text-align: center;
+  padding: 0 1rem;
+}
+
+.tagline {
+  margin-top: 0.5rem;
+  font-size: 1.25rem;
+  color: #555;
+}

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -2,7 +2,10 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import App from './App';
 
-test('renders app title', () => {
+test('renders intro layout', () => {
   render(<App />);
   expect(screen.getByRole('heading', { name: /todo vibe/i })).toBeInTheDocument();
+  expect(
+    screen.getByText(/organize your tasks with style/i)
+  ).toBeInTheDocument();
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,3 +1,10 @@
+import './App.css';
+
 export default function App() {
-  return <h1>Todo Vibe</h1>;
+  return (
+    <main className="intro">
+      <h1>Todo Vibe</h1>
+      <p className="tagline">Organize your tasks with style</p>
+    </main>
+  );
 }


### PR DESCRIPTION
## Summary
- add centered hero section with tagline
- style intro page with gradient background

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd2f5468f08330aeb86ea6cc9e10dd