### PR TITLE
feat: create first todo list from home

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,9 @@ A living guide to the AI (and human) roles that help us build a **clean, event-d
 
 ## Core Vocabulary
 
-* **Command** — an intention: `CreateTodo`, `RenameTodo`, `CompleteTodo`, `ScheduleDueDate`.
-* **Aggregate** — consistency boundary: `Todo`, `Project`, `Tag`.
-* **Event** — something that happened: `TodoCreated`, `TodoRenamed`, `TodoCompleted`, `DueDateScheduled`, `TodoReopened`, `TodoDeleted`, `TagAddedToTodo`, `TagRemovedFromTodo`.
+* **Command** — an intention: `CreateList`, `CreateTodo`, `RenameTodo`, `CompleteTodo`, `ScheduleDueDate`.
+* **Aggregate** — consistency boundary: `List` (collection of todos), `Todo`, `Project`, `Tag`.
+* **Event** — something that happened: `ListCreated`, `TodoCreated`, `TodoRenamed`, `TodoCompleted`, `DueDateScheduled`, `TodoReopened`, `TodoDeleted`, `TagAddedToTodo`, `TagRemovedFromTodo`.
 * **Read model** — query-optimized projections: e.g., “Today’s Tasks”, “Overdue by Project”.
 
 Keep names past-tense for events, imperative for commands, and align with ubiquitous language.
@@ -151,6 +151,7 @@ Each “agent” is a focused hat you (and I) can put on. Invoke one by name wit
 
 | Event                | Emitted When                    | Key Data                                     | Invariants                     |
 | -------------------- | ------------------------------- | -------------------------------------------- | ------------------------------ |
+| `ListCreated`        | `CreateList` accepted           | `listId`, `name`, `createdAt`                | Name non-empty                |
 | `TodoCreated`        | `CreateTodo` accepted           | `todoId`, `title`, `createdAt`, `projectId?` | Title non-empty                |
 | `TodoRenamed`        | `RenameTodo` on existing todo   | `todoId`, `newTitle`, `renamedAt`            | Title non-empty; changes value |
 | `TodoCompleted`      | `CompleteTodo` on not-done todo | `todoId`, `completedAt`                      | Can’t complete twice           |

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import App from './App';
+import { vi } from 'vitest';
 
 test('renders intro layout', () => {
   render(<App />);
@@ -8,4 +9,26 @@ test('renders intro layout', () => {
   expect(
     screen.getByText(/organize your tasks with style/i)
   ).toBeInTheDocument();
+});
+
+test('posts to create a new list', async () => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    json: () => Promise.resolve({ id: 'abc123' }),
+  } as any);
+  // @ts-expect-error: allow test-time override
+  global.fetch = fetchMock;
+
+  const assignMock = vi.fn();
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, assign: assignMock },
+    writable: true,
+  });
+
+  render(<App />);
+  const button = screen.getByRole('button', { name: /start a new list/i });
+  fireEvent.click(button);
+
+  await waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledWith('/api/lists', { method: 'POST' });
+  });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,10 +1,17 @@
 import './App.css';
 
 export default function App() {
+  async function createList() {
+    const response = await fetch('/api/lists', { method: 'POST' });
+    const { id } = await response.json();
+    window.location.assign(`/lists/${id}`);
+  }
+
   return (
     <main className="intro">
       <h1>Todo Vibe</h1>
       <p className="tagline">Organize your tasks with style</p>
+      <button onClick={createList}>Start a new list</button>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add call-to-action on home page to create a list via POST
- document List and ListCreated in AGENTS vocabulary
- cover list creation button with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd327541388330a650123e8b78fb1c