### PR TITLE
feat: add basic list creation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,14 @@ Domain events are documented in [EVENTS.md](EVENTS.md).
    ```
 
 Once you're set up, use TDD to drive new features and model behavior with events.
+
+## API
+
+### `POST /api/lists`
+
+Creates a new list and responds with its identifier.
+
+```sh
+curl -X POST http://localhost:3000/api/lists
+# => { "id": "abc123" }
+```

--- a/api.vitest.config.ts
+++ b/api.vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.api.spec.ts'],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test:domain": "tsx src/domain/todo/CreateTodo.spec.ts",
     "test:web": "vitest run",
-    "test": "npm run test:domain && npm run test:web",
+    "test:api": "vitest run -c api.vitest.config.ts",
+    "test": "npm run test:domain && npm run test:api && npm run test:web",
     "dev": "vite"
   },
   "dependencies": {

--- a/src/api/CreateList.api.spec.ts
+++ b/src/api/CreateList.api.spec.ts
@@ -1,0 +1,24 @@
+import { beforeAll, afterAll, expect, test } from 'vitest';
+import type { Server } from 'node:http';
+import { createApp } from '../server';
+
+let server: Server;
+let url: string;
+
+beforeAll(async () => {
+  server = createApp();
+  await new Promise(resolve => server.listen(0, resolve));
+  const { port } = server.address() as any;
+  url = `http://localhost:${port}`;
+});
+
+afterAll(() => {
+  server.close();
+});
+
+test('POST /api/lists returns an id', async () => {
+  const res = await fetch(`${url}/api/lists`, { method: 'POST' });
+  expect(res.status).toBe(201);
+  const body = await res.json();
+  expect(body).toMatchObject({ id: expect.any(String) });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,22 @@
+import http from 'node:http';
+import { randomUUID } from 'node:crypto';
+
+export function createApp() {
+  return http.createServer((req, res) => {
+    if (req.method === 'POST' && req.url === '/api/lists') {
+      const id = randomUUID();
+      res.writeHead(201, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ id }));
+      return;
+    }
+    res.statusCode = 404;
+    res.end();
+  });
+}
+
+if (import.meta.main) {
+  const port = process.env.PORT || 3000;
+  createApp().listen(port, () => {
+    console.log(`API listening on http://localhost:${port}`);
+  });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,11 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   root: 'web',
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000',
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- implement Node server with POST /api/lists returning generated id
- proxy Vite dev server to backend and document API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd34f606288330b621dcad631a318b