### PR TITLE
chore(docker): use tsx via --import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 COPY . .
-CMD ["node", "--loader", "tsx", "src/server.ts"]
+CMD ["node", "--import", "tsx", "src/server.ts"]


### PR DESCRIPTION
## Summary
- run server with tsx using Node's --import flag

## Testing
- `npm test` *(fails: Could not find a working container runtime strategy; Test Files 1 failed)*
- `docker-compose build api` *(fails: Error while fetching server API version)*
- `docker-compose up api` *(fails: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_68bd44d289f88330ab149791a30c2785