### PR TITLE
chore(db): add migration runner and lists table

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Domain events are documented in [EVENTS.md](EVENTS.md).
    npm test
    ```
 
+3. Run database migrations:
+
+   ```sh
+   npm run migrate
+   ```
+
 Once you're set up, use TDD to drive new features and model behavior with events.
 
 ## API
@@ -38,4 +44,10 @@ Start the API with a Postgres database:
 
 ```sh
 docker compose up
+```
+
+Run database migrations inside the container:
+
+```sh
+docker compose run api npm run migrate
 ```

--- a/migrations/0001-create-lists.sql
+++ b/migrations/0001-create-lists.sql
@@ -1,0 +1,3 @@
+CREATE TABLE lists (
+  id UUID PRIMARY KEY
+);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test:web": "vitest run",
     "test:api": "vitest run -c api.vitest.config.ts",
     "test": "npm run test:domain && npm run test:api && npm run test:web",
-    "dev": "vite"
+    "dev": "vite",
+    "migrate": "tsx src/migrate.ts"
   },
   "dependencies": {
     "pg": "^8.11.3",

--- a/src/api/CreateList.api.spec.ts
+++ b/src/api/CreateList.api.spec.ts
@@ -3,6 +3,7 @@ import type { Server } from 'node:http';
 import { createApp } from '../server';
 import { GenericContainer, type StartedTestContainer } from 'testcontainers';
 import { Pool } from 'pg';
+import { runMigrations } from '../migrate';
 
 let server: Server;
 let url: string;
@@ -24,7 +25,7 @@ beforeAll(async () => {
   db = new Pool({
     connectionString: `postgres://postgres:postgres@${host}:${port}/todos`,
   });
-  await db.query('CREATE TABLE lists (id uuid primary key)');
+  await runMigrations(db);
 
   server = createApp(db);
   await new Promise(resolve => server.listen(0, resolve));

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -1,0 +1,39 @@
+import { Pool } from 'pg';
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export async function runMigrations(pool?: Pool) {
+  const db = pool ?? new Pool({ connectionString: process.env.DATABASE_URL });
+  try {
+    await db.query(`CREATE TABLE IF NOT EXISTS migrations (id text PRIMARY KEY)`);
+    const migrationsDir = path.resolve('migrations');
+    const files = (await readdir(migrationsDir)).filter(f => f.endsWith('.sql')).sort();
+    for (const file of files) {
+      const { rows } = await db.query('SELECT 1 FROM migrations WHERE id = $1', [file]);
+      if (rows.length) continue;
+      const sql = await readFile(path.join(migrationsDir, file), 'utf8');
+      await db.query('BEGIN');
+      try {
+        await db.query(sql);
+        await db.query('INSERT INTO migrations(id) VALUES($1)', [file]);
+        await db.query('COMMIT');
+        console.log(`applied ${file}`);
+      } catch (err) {
+        await db.query('ROLLBACK');
+        throw err;
+      }
+    }
+  } finally {
+    if (!pool) {
+      await db.end();
+    }
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  runMigrations().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- add migrations directory with initial lists table
- implement migration runner and npm script
- document how to run migrations locally and in docker

## Testing
- `npm test` *(fails: Could not find a working container runtime strategy)*

------
https://chatgpt.com/codex/tasks/task_e_68bd50ca92608330b8c5b7d068d42d5a