### PR TITLE
feat(docker): run migrations before api startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,8 @@ curl -X POST http://localhost:3000/api/lists
 
 ## Running with Docker Compose
 
-Start the API with a Postgres database:
+Start the stack; migrations run before the API begins accepting requests:
 
 ```sh
 docker compose up
-```
-
-Run database migrations inside the container:
-
-```sh
-docker compose run api npm run migrate
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,19 @@ services:
       - DATABASE_URL=postgres://postgres:postgres@db:5432/todos
       - PORT=3000
     depends_on:
-      - db
+      migrate:
+        condition: service_completed_successfully
     ports:
       - '3000:3000'
+  migrate:
+    build: .
+    environment:
+      - DATABASE_URL=postgres://postgres:postgres@db:5432/todos
+    depends_on:
+      db:
+        condition: service_healthy
+    command: npm run migrate
+    restart: "no"
   db:
     image: postgres:16-alpine
     environment:
@@ -17,3 +27,8 @@ services:
       POSTGRES_DB: todos
     ports:
       - '5432:5432'
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
## Summary
- add migrate service and wait for DB health before API starts
- update docs to note migrations run automatically via docker compose

## Testing
- `npm run test:domain`
- `npm run test:web`
- `npm run test:api` *(fails: Failed to load url testcontainers in CreateList.api.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bd52c40f448330beb8688b671a047b