### PR TITLE
Add list page and route for new todo lists

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -38,5 +38,6 @@ test('posts to create a new list', async () => {
 
   await waitFor(() => {
     expect(fetchMock).toHaveBeenCalledWith('/api/lists', { method: 'POST' });
+    expect(assignMock).toHaveBeenCalledWith('/lists/abc123');
   });
 });

--- a/web/src/List.css
+++ b/web/src/List.css
@@ -1,0 +1,19 @@
+.list {
+  min-height: 100vh;
+  padding: 2rem;
+  font-family: system-ui, sans-serif;
+  background: #fff;
+  color: #333;
+}
+
+.list h1 {
+  margin-bottom: 1rem;
+}
+
+.list input {
+  width: 100%;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}

--- a/web/src/List.test.tsx
+++ b/web/src/List.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import List from './List';
+
+test('renders layout for a new todo list', () => {
+  render(<List />);
+  expect(screen.getByRole('heading', { name: /new list/i })).toBeInTheDocument();
+  expect(screen.getByPlaceholderText(/add a todo/i)).toBeInTheDocument();
+});

--- a/web/src/List.tsx
+++ b/web/src/List.tsx
@@ -1,0 +1,11 @@
+import './List.css';
+
+export default function List() {
+  return (
+    <main className="list">
+      <h1>New List</h1>
+      <input placeholder="Add a todo" />
+      <ul></ul>
+    </main>
+  );
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import List from './List';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+const root = ReactDOM.createRoot(document.getElementById('root')!);
+const Component = window.location.pathname.startsWith('/lists/') ? List : App;
+
+root.render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>
+    <Component />
+  </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- navigate to a new list page after creating a list
- add minimal list page component and styling
- switch root render based on pathname

## Testing
- `npm test` (fails: Failed to load url testcontainers)
- `npm run test:web`


------
https://chatgpt.com/codex/tasks/task_e_68bd57a0887083308fbab5db5ce682e8