### PR TITLE
feat: allow creating todos

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ curl -X POST http://localhost:3000/api/lists
 # => { "id": "abc123" }
 ```
 
+### `POST /api/todos`
+
+Creates a new todo item in a list and responds with its identifier.
+
+```sh
+curl -X POST http://localhost:3000/api/todos \\
+  -H 'Content-Type: application/json' \\
+  -d '{"listId":"abc123","title":"Buy milk"}'
+# => { "id": "def456" }
+```
+
 ## Running with Docker Compose
 
 Start the stack; migrations run before the API begins accepting requests:

--- a/migrations/0003-create-todos.sql
+++ b/migrations/0003-create-todos.sql
@@ -1,0 +1,6 @@
+CREATE TABLE todos (
+  id UUID PRIMARY KEY,
+  list_id UUID REFERENCES lists(id),
+  title TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL
+);

--- a/src/api/CreateTodo.api.spec.ts
+++ b/src/api/CreateTodo.api.spec.ts
@@ -1,0 +1,65 @@
+import { beforeAll, afterAll, expect, test } from 'vitest';
+import type { Server } from 'node:http';
+import { createApp } from '../server';
+import { GenericContainer, type StartedTestContainer } from 'testcontainers';
+import { Pool } from 'pg';
+import { runMigrations } from '../migrate';
+
+let server: Server;
+let url: string;
+let db: Pool;
+let pg: StartedTestContainer;
+
+beforeAll(async () => {
+  pg = await new GenericContainer('postgres:16-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'postgres',
+      POSTGRES_PASSWORD: 'postgres',
+      POSTGRES_DB: 'todos',
+    })
+    .withExposedPorts(5432)
+    .start();
+
+  const host = pg.getHost();
+  const port = pg.getMappedPort(5432);
+  db = new Pool({
+    connectionString: `postgres://postgres:postgres@${host}:${port}/todos`,
+  });
+  await runMigrations(db);
+
+  server = createApp(db);
+  await new Promise(resolve => server.listen(0, resolve));
+  const { port: serverPort } = server.address() as any;
+  url = `http://localhost:${serverPort}`;
+});
+
+afterAll(async () => {
+  await db.end();
+  await pg.stop();
+  server.close();
+});
+
+test('POST /api/todos accepts a title and listId and stores it', async () => {
+  const listRes = await fetch(`${url}/api/lists`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'Groceries' }),
+  });
+  const { id: listId } = await listRes.json();
+
+  const res = await fetch(`${url}/api/todos`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ listId, title: 'Buy milk' }),
+  });
+  expect(res.status).toBe(201);
+  const body = await res.json();
+  expect(body).toMatchObject({ id: expect.any(String) });
+  const saved = await db.query('SELECT id, title, list_id FROM todos WHERE id = $1', [body.id]);
+  expect(saved.rows[0]).toMatchObject({ id: body.id, title: 'Buy milk', list_id: listId });
+
+  const getRes = await fetch(`${url}/api/todos/${body.id}`);
+  expect(getRes.status).toBe(200);
+  const todo = await getRes.json();
+  expect(todo).toEqual({ id: body.id, title: 'Buy milk', listId });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import http from 'node:http';
 import { randomUUID } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { Pool } from 'pg';
+import { CreateTodo } from './domain/todo/CreateTodo';
 
 export function createApp(db: Pool = new Pool({ connectionString: process.env.DATABASE_URL })) {
   return http.createServer(async (req, res) => {
@@ -13,6 +14,42 @@ export function createApp(db: Pool = new Pool({ connectionString: process.env.DA
       await db.query('INSERT INTO lists(id, name) VALUES($1, $2)', [id, name]);
       res.writeHead(201, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ id }));
+      return;
+    }
+
+    if (req.method === 'POST' && req.url === '/api/todos') {
+      let body = '';
+      for await (const chunk of req) body += chunk;
+      const { listId, title } = body ? JSON.parse(body) : { title: '' };
+      const id = randomUUID();
+      const createdAt = new Date();
+      CreateTodo({ todoId: id, title, createdAt });
+      await db.query(
+        'INSERT INTO todos(id, list_id, title, created_at) VALUES($1, $2, $3, $4)',
+        [id, listId, title, createdAt]
+      );
+      res.writeHead(201, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ id }));
+      return;
+    }
+
+    const todoMatch = req.url?.match(/^\/api\/todos\/([\w-]+)$/);
+    if (req.method === 'GET' && todoMatch) {
+      const id = todoMatch[1];
+      const { rows } = await db.query(
+        'SELECT id, list_id, title FROM todos WHERE id = $1',
+        [id]
+      );
+      if (rows.length === 0) {
+        res.statusCode = 404;
+        res.end();
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      const row = rows[0];
+      res.end(
+        JSON.stringify({ id: row.id, title: row.title, listId: row.list_id })
+      );
       return;
     }
 

--- a/web/src/List.test.tsx
+++ b/web/src/List.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi, afterEach } from 'vitest';
 import List from './List';
@@ -28,4 +28,38 @@ test('renders list name fetched from the server', async () => {
   await screen.findByRole('heading', { name: 'Groceries' });
   expect(fetchMock).toHaveBeenCalledWith('/api/lists/abc123');
   expect(screen.getByPlaceholderText(/add a todo/i)).toBeInTheDocument();
+});
+
+test('posts to create a new todo and displays it', async () => {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve({ id: 'abc123', name: 'Groceries' }),
+    } as any)
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve({ id: 'todo123' }),
+    } as any);
+  // @ts-expect-error test override
+  global.fetch = fetchMock;
+
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, pathname: '/lists/abc123' },
+    writable: true,
+  });
+
+  render(<List />);
+
+  const input = await screen.findByPlaceholderText(/add a todo/i);
+  fireEvent.change(input, { target: { value: 'Buy milk' } });
+  fireEvent.keyDown(input, { key: 'Enter' });
+
+  await waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledWith('/api/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ listId: 'abc123', title: 'Buy milk' }),
+    });
+  });
+
+  expect(await screen.findByText('Buy milk')).toBeInTheDocument();
 });

--- a/web/src/List.tsx
+++ b/web/src/List.tsx
@@ -1,21 +1,51 @@
 import { useEffect, useState } from 'react';
 import './List.css';
 
+interface Todo {
+  id: string;
+  title: string;
+}
+
 export default function List() {
   const [name, setName] = useState('New List');
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [title, setTitle] = useState('');
+  const id = window.location.pathname.split('/').pop();
 
   useEffect(() => {
-    const id = window.location.pathname.split('/').pop();
     fetch(`/api/lists/${id}`)
       .then(res => res.json())
       .then(data => setName(data.name));
-  }, []);
+  }, [id]);
+
+  async function addTodo() {
+    if (!title.trim()) return;
+    const res = await fetch('/api/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ listId: id, title }),
+    });
+    const { id: todoId } = await res.json();
+    setTodos(t => [...t, { id: todoId, title }]);
+    setTitle('');
+  }
 
   return (
     <main className="list">
       <h1>{name}</h1>
-      <input placeholder="Add a todo" />
-      <ul></ul>
+      <input
+        placeholder="Add a todo"
+        value={title}
+        onChange={e => setTitle(e.target.value)}
+        onKeyDown={e => {
+          if (e.key === 'Enter') addTodo();
+        }}
+      />
+      <ul>
+        {todos.map(todo => (
+          <li key={todo.id}>{todo.title}</li>
+        ))}
+      </ul>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add POST /api/todos endpoint to store todos and expose GET /api/todos/:id
- allow adding todos from list page
- document todo creation endpoint and database migration

## Testing
- `npm run test:domain`
- `npm run test:web`
- `npm run test:api` *(fails: Could not find a working container runtime strategy)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5c16897c8330a9c1a055cb6b7732