### PR TITLE
feat(web): style pages with award-worthy theme

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Todo Vibe</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1,13 +1,24 @@
+:root {
+  --primary: #4f46e5;
+  --accent: #f472b6;
+  --bg-start: #f0f4ff;
+  --bg-end: #d9e8ff;
+}
+
+body {
+  margin: 0;
+  font-family: 'Poppins', system-ui, sans-serif;
+  background: linear-gradient(135deg, var(--bg-start), var(--bg-end));
+}
+
 .intro {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-family: system-ui, sans-serif;
-  background: linear-gradient(135deg, #f0f4ff, #d9e8ff);
-  color: #333;
   text-align: center;
+  color: #333;
   padding: 0 1rem;
 }
 
@@ -15,4 +26,23 @@
   margin-top: 0.5rem;
   font-size: 1.25rem;
   color: #555;
+}
+
+.start-button {
+  margin-top: 2rem;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 9999px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.start-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
 }

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -9,6 +9,9 @@ test('renders intro layout', () => {
   expect(
     screen.getByText(/organize your tasks with style/i)
   ).toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: /start a new list/i })
+  ).toHaveClass('start-button');
 });
 
 const originalFetch = global.fetch;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,7 +16,9 @@ export default function App() {
     <main className="intro">
       <h1>Todo Vibe</h1>
       <p className="tagline">Organize your tasks with style</p>
-      <button onClick={createList}>Start a new list</button>
+      <button className="start-button" onClick={createList}>
+        Start a new list
+      </button>
     </main>
   );
 }

--- a/web/src/List.css
+++ b/web/src/List.css
@@ -1,8 +1,20 @@
+:root {
+  --primary: #4f46e5;
+  --accent: #f472b6;
+  --bg-start: #f0f4ff;
+  --bg-end: #d9e8ff;
+}
+
+.list,
+body {
+  margin: 0;
+}
+
 .list {
   min-height: 100vh;
   padding: 2rem;
-  font-family: system-ui, sans-serif;
-  background: #fff;
+  font-family: 'Poppins', system-ui, sans-serif;
+  background: linear-gradient(135deg, var(--bg-start), var(--bg-end));
   color: #333;
 }
 
@@ -10,15 +22,41 @@
   margin-bottom: 1rem;
 }
 
-.list input {
+.list input[type="text"] {
   width: 100%;
-  padding: 0.5rem;
+  padding: 0.75rem 1rem;
   margin-bottom: 1rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  border: none;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.list li.completed {
+.list ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.todo-item {
+  background: #fff;
+  margin-bottom: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.todo-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.todo-item.completed {
   text-decoration: line-through;
   color: #888;
+  background: #f9f9f9;
+}
+
+.list input[type="checkbox"] {
+  accent-color: var(--primary);
 }

--- a/web/src/List.test.tsx
+++ b/web/src/List.test.tsx
@@ -60,8 +60,9 @@ test('posts to create a new todo and displays it', async () => {
       body: JSON.stringify({ listId: 'abc123', title: 'Buy milk' }),
     });
   });
-
-  expect(await screen.findByText('Buy milk')).toBeInTheDocument();
+  const label = await screen.findByText('Buy milk');
+  expect(label).toBeInTheDocument();
+  expect(label.closest('li')).toHaveClass('todo-item');
 });
 
 test('checks off a todo and sends completion to the server', async () => {

--- a/web/src/List.tsx
+++ b/web/src/List.tsx
@@ -44,6 +44,7 @@ export default function List() {
     <main className="list">
       <h1>{name}</h1>
       <input
+        type="text"
         placeholder="Add a todo"
         value={title}
         onChange={e => setTitle(e.target.value)}
@@ -53,7 +54,10 @@ export default function List() {
       />
       <ul>
         {todos.map(todo => (
-          <li key={todo.id} className={todo.completed ? 'completed' : ''}>
+          <li
+            key={todo.id}
+            className={`todo-item${todo.completed ? ' completed' : ''}`}
+          >
             <label>
               <input
                 type="checkbox"


### PR DESCRIPTION
## Summary
- add vibrant gradient theme and custom Poppins font
- style call-to-action button and todo items with hover transitions
- adjust tests to assert new styling hooks

## Testing
- `npm test` *(fails: Could not find a working container runtime strategy)*
- `npm run test:web`


------
https://chatgpt.com/codex/tasks/task_e_68bd63f2bf4c833097c03ac9c43f3c4d