### PR TITLE
feat(todo): allow reopening completed todos

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -26,3 +26,16 @@ Emitted when a todo is marked as completed.
 ### Notes
 
 - Currently no guard against double completion.
+
+## TodoReopened
+
+Emitted when a completed todo is reopened.
+
+### Data
+
+- `todoId`: string
+- `reopenedAt`: Date
+
+### Notes
+
+- Only allowed if the todo was previously completed and not already reopened.

--- a/src/domain/todo/ReopenTodo.spec.ts
+++ b/src/domain/todo/ReopenTodo.spec.ts
@@ -1,0 +1,26 @@
+import { strict as assert } from 'node:assert';
+import { ReopenTodo } from './ReopenTodo';
+import type { TodoEvent, TodoReopened } from './events';
+
+const todoId = '1';
+const reopenedAt = new Date('2023-01-03T00:00:00Z');
+
+{
+  const history: TodoEvent[] = [
+    { type: 'TodoCreated', data: { todoId, title: 'Test', createdAt: new Date('2023-01-01T00:00:00Z') } },
+    { type: 'TodoCompleted', data: { todoId, completedAt: new Date('2023-01-02T00:00:00Z') } }
+  ];
+
+  const result: TodoReopened[] = ReopenTodo({ todoId, reopenedAt, history });
+  assert.deepStrictEqual(result, [
+    { type: 'TodoReopened', data: { todoId, reopenedAt } }
+  ]);
+}
+
+{
+  const history: TodoEvent[] = [
+    { type: 'TodoCreated', data: { todoId, title: 'Test', createdAt: new Date('2023-01-01T00:00:00Z') } }
+  ];
+
+  assert.throws(() => ReopenTodo({ todoId, reopenedAt, history }), /completed/i);
+}

--- a/src/domain/todo/ReopenTodo.ts
+++ b/src/domain/todo/ReopenTodo.ts
@@ -1,0 +1,26 @@
+import type { TodoEvent, TodoReopened } from './events';
+
+export function ReopenTodo({
+  todoId,
+  reopenedAt,
+  history,
+}: {
+  todoId: string;
+  reopenedAt: Date;
+  history: TodoEvent[];
+}): TodoReopened[] {
+  let completed = false;
+  for (const event of history) {
+    if (event.type === 'TodoCompleted') completed = true;
+    if (event.type === 'TodoReopened') completed = false;
+  }
+  if (!completed) {
+    throw new Error('todo is not completed');
+  }
+  return [
+    {
+      type: 'TodoReopened',
+      data: { todoId, reopenedAt },
+    },
+  ];
+}

--- a/src/domain/todo/events.ts
+++ b/src/domain/todo/events.ts
@@ -15,4 +15,12 @@ export interface TodoCompleted {
   };
 }
 
-export type TodoEvent = TodoCreated | TodoCompleted;
+export interface TodoReopened {
+  type: 'TodoReopened';
+  data: {
+    todoId: string;
+    reopenedAt: Date;
+  };
+}
+
+export type TodoEvent = TodoCreated | TodoCompleted | TodoReopened;

--- a/web/src/List.test.tsx
+++ b/web/src/List.test.tsx
@@ -51,9 +51,10 @@ test('adds a new todo and displays it', async () => {
 
   await waitFor(() => {
     const saved = JSON.parse(localStorage.getItem('list:abc123')!);
-    expect(saved.todos).toEqual([
-      { id: 'todo123', title: 'Buy milk', completed: false },
-    ]);
+    expect(saved.todos[0].id).toBe('todo123');
+    expect(saved.todos[0].title).toBe('Buy milk');
+    expect(saved.todos[0].completed).toBe(false);
+    expect(saved.todos[0].events[0].type).toBe('TodoCreated');
     expect(uuidMock).toHaveBeenCalled();
   });
   const label = await screen.findByText('Buy milk');
@@ -67,7 +68,7 @@ test('checks off a todo and persists completion', async () => {
     JSON.stringify({
       id: 'abc123',
       name: 'Groceries',
-      todos: [{ id: 'todo123', title: 'Buy milk', completed: false }],
+      todos: [{ id: 'todo123', title: 'Buy milk', completed: false, events: [] }],
     })
   );
 
@@ -84,6 +85,7 @@ test('checks off a todo and persists completion', async () => {
   await waitFor(() => {
     const saved = JSON.parse(localStorage.getItem('list:abc123')!);
     expect(saved.todos[0].completed).toBe(true);
+    expect(saved.todos[0].events[0].type).toBe('TodoCompleted');
   });
 
   expect(checkbox).toBeChecked();

--- a/web/src/List.tsx
+++ b/web/src/List.tsx
@@ -1,10 +1,15 @@
 import { useEffect, useState } from 'react';
 import './List.css';
+import { CreateTodo } from '../../src/domain/todo/CreateTodo';
+import { CompleteTodo } from '../../src/domain/todo/CompleteTodo';
+import { ReopenTodo } from '../../src/domain/todo/ReopenTodo';
+import type { TodoEvent } from '../../src/domain/todo/events';
 
 interface Todo {
   id: string;
   title: string;
   completed: boolean;
+  events: TodoEvent[];
 }
 
 export default function List() {
@@ -18,14 +23,15 @@ export default function List() {
     if (stored) {
       const list = JSON.parse(stored);
       setName(list.name);
-      setTodos(list.todos || []);
+      setTodos((list.todos || []).map((t: Todo) => ({ ...t, events: t.events || [] })));
     }
   }, [id]);
 
   async function addTodo() {
     if (!title.trim()) return;
     const todoId = crypto.randomUUID();
-    const newTodo = { id: todoId, title, completed: false };
+    const events = CreateTodo({ todoId, title, createdAt: new Date() });
+    const newTodo: Todo = { id: todoId, title, completed: false, events };
     const stored = localStorage.getItem(`list:${id}`);
     const list = stored ? JSON.parse(stored) : { id, name, todos: [] };
     list.todos.push(newTodo);
@@ -38,9 +44,17 @@ export default function List() {
     const stored = localStorage.getItem(`list:${id}`);
     if (!stored) return;
     const list = JSON.parse(stored);
-    list.todos = list.todos.map((td: Todo) =>
-      td.id === todo.id ? { ...td, completed } : td
-    );
+    list.todos = list.todos.map((td: Todo) => {
+      if (td.id !== todo.id) return td;
+      const events = td.events || [];
+      if (completed) {
+        const newEvents = CompleteTodo({ todoId: td.id, completedAt: new Date() });
+        return { ...td, completed: true, events: [...events, ...newEvents] };
+      } else {
+        const newEvents = ReopenTodo({ todoId: td.id, reopenedAt: new Date(), history: events });
+        return { ...td, completed: false, events: [...events, ...newEvents] };
+      }
+    });
     localStorage.setItem(`list:${id}`, JSON.stringify(list));
     setTodos(list.todos);
   }


### PR DESCRIPTION
## Summary
- add TodoReopened event and command to reopen completed todos
- document TodoReopened and persist events through UI
- trigger ReopenTodo from UI when unchecking a completed todo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be136b01b483308dc36ac7229b36a2