### PR TITLE
feat: allow reordering todo items

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -39,3 +39,17 @@ Emitted when a completed todo is reopened.
 ### Notes
 
 - Only allowed if the todo was previously completed and not already reopened.
+
+## TodoReordered
+
+Emitted when a todo is moved to a new position within its list.
+
+### Data
+
+- `todoId`: string
+- `fromIndex`: number
+- `toIndex`: number
+
+### Notes
+
+- No event is emitted if the todo stays in the same position.

--- a/migrations/0005-add-position-to-todos.sql
+++ b/migrations/0005-add-position-to-todos.sql
@@ -1,0 +1,2 @@
+ALTER TABLE todos ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+CREATE INDEX IF NOT EXISTS todos_list_position_idx ON todos(list_id, position);

--- a/src/domain/todo/ReorderTodo.spec.ts
+++ b/src/domain/todo/ReorderTodo.spec.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from 'node:assert';
+import { ReorderTodo } from './ReorderTodo';
+import type { TodoEvent, TodoReordered } from './events';
+
+const history: TodoEvent[] = [
+  { type: 'TodoCreated', data: { todoId: 'a', title: 'A', createdAt: new Date('2023-01-01T00:00:00Z') } },
+  { type: 'TodoCreated', data: { todoId: 'b', title: 'B', createdAt: new Date('2023-01-01T00:00:01Z') } },
+  { type: 'TodoCreated', data: { todoId: 'c', title: 'C', createdAt: new Date('2023-01-01T00:00:02Z') } },
+];
+
+{
+  const result: TodoReordered[] = ReorderTodo({ todoId: 'c', toIndex: 0, history });
+  assert.deepStrictEqual(result, [
+    { type: 'TodoReordered', data: { todoId: 'c', fromIndex: 2, toIndex: 0 } },
+  ]);
+}
+
+assert.deepStrictEqual(ReorderTodo({ todoId: 'a', toIndex: 0, history }), []);
+
+assert.throws(() => ReorderTodo({ todoId: 'x', toIndex: 0, history }), /exist/i);

--- a/src/domain/todo/ReorderTodo.ts
+++ b/src/domain/todo/ReorderTodo.ts
@@ -1,0 +1,32 @@
+import type { TodoEvent, TodoReordered } from './events';
+
+export function ReorderTodo({
+  todoId,
+  toIndex,
+  history,
+}: {
+  todoId: string;
+  toIndex: number;
+  history: TodoEvent[];
+}): TodoReordered[] {
+  const order: string[] = [];
+  for (const event of history) {
+    if (event.type === 'TodoCreated') {
+      order.push(event.data.todoId);
+    } else if (event.type === 'TodoReordered') {
+      const { fromIndex, toIndex } = event.data;
+      const [moved] = order.splice(fromIndex, 1);
+      order.splice(toIndex, 0, moved);
+    }
+  }
+  const fromIndex = order.indexOf(todoId);
+  if (fromIndex === -1) throw new Error('todo does not exist');
+  if (toIndex < 0 || toIndex >= order.length) throw new Error('index out of bounds');
+  if (fromIndex === toIndex) return [];
+  return [
+    {
+      type: 'TodoReordered',
+      data: { todoId, fromIndex, toIndex },
+    },
+  ];
+}

--- a/src/domain/todo/events.ts
+++ b/src/domain/todo/events.ts
@@ -23,4 +23,17 @@ export interface TodoReopened {
   };
 }
 
-export type TodoEvent = TodoCreated | TodoCompleted | TodoReopened;
+export interface TodoReordered {
+  type: 'TodoReordered';
+  data: {
+    todoId: string;
+    fromIndex: number;
+    toIndex: number;
+  };
+}
+
+export type TodoEvent =
+  | TodoCreated
+  | TodoCompleted
+  | TodoReopened
+  | TodoReordered;

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { Pool } from 'pg';
 import { CreateTodo } from './domain/todo/CreateTodo';
 import { CompleteTodo } from './domain/todo/CompleteTodo';
+import { ReorderTodo } from './domain/todo/ReorderTodo';
 
 export function createApp(db: Pool = new Pool({ connectionString: process.env.DATABASE_URL })) {
   return http.createServer(async (req, res) => {
@@ -25,9 +26,12 @@ export function createApp(db: Pool = new Pool({ connectionString: process.env.DA
       const id = randomUUID();
       const createdAt = new Date();
       CreateTodo({ todoId: id, title, createdAt });
+      const {
+        rows: [{ pos }],
+      } = await db.query('SELECT COALESCE(MAX(position) + 1, 0) AS pos FROM todos WHERE list_id = $1', [listId]);
       await db.query(
-        'INSERT INTO todos(id, list_id, title, created_at, completed) VALUES($1, $2, $3, $4, false)',
-        [id, listId, title, createdAt]
+        'INSERT INTO todos(id, list_id, title, created_at, completed, position) VALUES($1, $2, $3, $4, false, $5)',
+        [id, listId, title, createdAt, pos]
       );
       res.writeHead(201, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ id }));
@@ -67,6 +71,50 @@ export function createApp(db: Pool = new Pool({ connectionString: process.env.DA
         res.end();
         return;
       }
+
+    const reorderMatch = req.url?.match(/^\/api\/lists\/([\w-]+)\/todos\/([\w-]+)\/reorder$/);
+    if (req.method === 'PATCH' && reorderMatch) {
+      const [_, listId, todoId] = reorderMatch;
+      let body = '';
+      for await (const chunk of req) body += chunk;
+      const { toIndex } = JSON.parse(body);
+      const {
+        rows: all,
+      } = await db.query('SELECT id FROM todos WHERE list_id = $1 ORDER BY position', [listId]);
+      const history = all.map((r: any) => ({
+        type: 'TodoCreated',
+        data: { todoId: r.id, title: '', createdAt: new Date() },
+      }));
+      const events = ReorderTodo({ todoId, toIndex, history });
+      if (events.length === 0) {
+        res.statusCode = 204;
+        res.end();
+        return;
+      }
+      const { fromIndex } = events[0].data;
+      await db.query('BEGIN');
+      try {
+        if (toIndex > fromIndex) {
+          await db.query(
+            'UPDATE todos SET position = position - 1 WHERE list_id = $1 AND position > $2 AND position <= $3',
+            [listId, fromIndex, toIndex]
+          );
+        } else {
+          await db.query(
+            'UPDATE todos SET position = position + 1 WHERE list_id = $1 AND position >= $2 AND position < $3',
+            [listId, toIndex, fromIndex]
+          );
+        }
+        await db.query('UPDATE todos SET position = $1 WHERE id = $2', [toIndex, todoId]);
+        await db.query('COMMIT');
+      } catch (err) {
+        await db.query('ROLLBACK');
+        throw err;
+      }
+      res.statusCode = 204;
+      res.end();
+      return;
+    }
 
     const match = req.url?.match(/^\/api\/lists\/([\w-]+)$/);
     if (req.method === 'GET' && match) {


### PR DESCRIPTION
## Summary
- add TodoReordered event and command
- support drag-and-drop reordering with persisted positions
- expose server endpoint and migration for todo positions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be1d402abc8330b983b281ff62ecae