### PR TITLE
feat(web): show reorder feedback during drag

### DIFF
--- a/web/src/List.css
+++ b/web/src/List.css
@@ -46,6 +46,10 @@ body {
   transition: transform 0.2s, box-shadow 0.2s;
 }
 
+.todo-item.dragging {
+  background: #e0e7ff;
+}
+
 .todo-item:hover {
   transform: translateY(-2px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);

--- a/web/src/List.test.tsx
+++ b/web/src/List.test.tsx
@@ -127,12 +127,14 @@ test('reorders todos via drag and drop', async () => {
     setDragImage: () => {},
   };
   fireEvent.dragStart(secondLi, { dataTransfer: data });
+  await waitFor(() => expect(secondLi).toHaveClass('dragging'));
   fireEvent.dragOver(firstLi, { dataTransfer: data });
   await waitFor(() => {
     const duringDrag = screen.getAllByRole('listitem');
     expect(duringDrag[0]).toHaveTextContent('B');
   });
   fireEvent.drop(firstLi, { dataTransfer: data });
+  await waitFor(() => expect(secondLi).not.toHaveClass('dragging'));
 
   await waitFor(() => {
     const saved = JSON.parse(localStorage.getItem('list:abc123')!);

--- a/web/src/List.test.tsx
+++ b/web/src/List.test.tsx
@@ -128,6 +128,10 @@ test('reorders todos via drag and drop', async () => {
   };
   fireEvent.dragStart(secondLi, { dataTransfer: data });
   fireEvent.dragOver(firstLi, { dataTransfer: data });
+  await waitFor(() => {
+    const duringDrag = screen.getAllByRole('listitem');
+    expect(duringDrag[0]).toHaveTextContent('B');
+  });
   fireEvent.drop(firstLi, { dataTransfer: data });
 
   await waitFor(() => {

--- a/web/src/List.tsx
+++ b/web/src/List.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import './List.css';
 import { CreateTodo } from '../../src/domain/todo/CreateTodo';
 import { CompleteTodo } from '../../src/domain/todo/CompleteTodo';
@@ -18,6 +18,7 @@ export default function List() {
   const [todos, setTodos] = useState<Todo[]>([]);
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [title, setTitle] = useState('');
+  const originalOrder = useRef<Todo[]>([]);
   const id = window.location.pathname.split('/').pop();
 
   useEffect(() => {
@@ -65,29 +66,38 @@ export default function List() {
     setTodos(list.todos);
   }
 
-  function handleDrop(toIndex: number) {
+  function handleDragOver(toIndex: number) {
+    if (dragIndex === null || dragIndex === toIndex) return;
+    const updated = [...todos];
+    const [moved] = updated.splice(dragIndex, 1);
+    updated.splice(toIndex, 0, moved);
+    setTodos(updated);
+    setDragIndex(toIndex);
+  }
+
+  function handleDrop() {
     if (dragIndex === null) return;
-    const history: TodoEvent[] = todos.map(t => ({
+    const history: TodoEvent[] = originalOrder.current.map(t => ({
       type: 'TodoCreated',
       data: { todoId: t.id, title: t.title, createdAt: new Date() },
     }));
-    const events = ReorderTodo({
-      todoId: todos[dragIndex].id,
-      toIndex,
-      history,
-    });
+    const events = ReorderTodo({ todoId: todos[dragIndex].id, toIndex: dragIndex, history });
     if (events.length === 0) {
+      setTodos(originalOrder.current);
       setDragIndex(null);
+      originalOrder.current = [];
       return;
     }
     const updated = [...todos];
-    const [moved] = updated.splice(dragIndex, 1);
-    const movedWithEvents = { ...moved, events: [...(moved.events || []), ...events] };
-    updated.splice(toIndex, 0, movedWithEvents);
+    updated[dragIndex] = {
+      ...updated[dragIndex],
+      events: [...(updated[dragIndex].events || []), ...events],
+    };
     const stored = { id, name, todos: updated };
     localStorage.setItem(`list:${id}`, JSON.stringify(stored));
     setTodos(updated);
     setDragIndex(null);
+    originalOrder.current = [];
   }
 
   return (
@@ -108,9 +118,15 @@ export default function List() {
             key={todo.id}
             className={`todo-item${todo.completed ? ' completed' : ''}`}
             draggable
-            onDragStart={() => setDragIndex(i)}
-            onDragOver={e => e.preventDefault()}
-            onDrop={() => handleDrop(i)}
+            onDragStart={() => {
+              originalOrder.current = todos;
+              setDragIndex(i);
+            }}
+            onDragOver={e => {
+              e.preventDefault();
+              handleDragOver(i);
+            }}
+            onDrop={handleDrop}
           >
             <label>
               <input

--- a/web/src/List.tsx
+++ b/web/src/List.tsx
@@ -116,7 +116,7 @@ export default function List() {
         {todos.map((todo, i) => (
           <li
             key={todo.id}
-            className={`todo-item${todo.completed ? ' completed' : ''}`}
+            className={`todo-item${todo.completed ? ' completed' : ''}${dragIndex === i ? ' dragging' : ''}`}
             draggable
             onDragStart={() => {
               originalOrder.current = todos;
@@ -127,6 +127,7 @@ export default function List() {
               handleDragOver(i);
             }}
             onDrop={handleDrop}
+            onDragEnd={() => setDragIndex(null)}
           >
             <label>
               <input


### PR DESCRIPTION
## Summary
- reorder todo items on drag-over for clearer drop position
- persist final order and events when drop completes
- test dynamic reordering during drag

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be3e116e4c8330b9db90356081af25