### PR TITLE
feat: download saved lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ See [AGENTS.md](AGENTS.md) for collaboration guidelines and event-driven/TDD con
    npm run dev
    ```
 
-Open the browser at the URL printed in the console to create lists and todos. Data persists locally in your browser between sessions, and you can download all saved lists as a JSON backup via the **Download state** button.
+Open the browser at the URL printed in the console to create lists and todos. Data persists locally in your browser between sessions, and you can export all saved lists as a JSON backup from the menu in the top right.

--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ See [AGENTS.md](AGENTS.md) for collaboration guidelines and event-driven/TDD con
    npm run dev
    ```
 
-Open the browser at the URL printed in the console to create lists and todos. Data persists locally in your browser between sessions.
+Open the browser at the URL printed in the console to create lists and todos. Data persists locally in your browser between sessions, and you can download all saved lists as a JSON backup via the **Download state** button.

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -20,6 +20,7 @@ body {
   text-align: center;
   color: #333;
   padding: 0 1rem;
+  position: relative;
 }
 
 .tagline {
@@ -45,4 +46,24 @@ body {
 .start-button:hover {
   transform: translateY(-2px);
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+}
+
+.menu-button {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.menu {
+  position: absolute;
+  top: 3rem;
+  right: 1rem;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -66,4 +66,28 @@ body {
   border: 1px solid #ccc;
   padding: 0.5rem;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.menu-item {
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.menu-item:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -81,7 +81,9 @@ test('exports all lists as a json file', async () => {
 
   render(<App />);
   fireEvent.click(screen.getByLabelText(/menu/i));
-  fireEvent.click(screen.getByRole('button', { name: /export state/i }));
+  const exportButton = screen.getByRole('button', { name: /export state/i });
+  expect(exportButton).toHaveClass('menu-item');
+  fireEvent.click(exportButton);
 
   await waitFor(() => {
     expect(urlSpy).toHaveBeenCalled();

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -55,7 +55,7 @@ test('stores a new list in local storage with a name', async () => {
   });
 });
 
-test('downloads all lists as a json file', async () => {
+test('exports all lists as a json file', async () => {
   localStorage.setItem(
     'list:l1',
     JSON.stringify({ id: 'l1', name: 'Groceries', todos: [] })
@@ -80,7 +80,8 @@ test('downloads all lists as a json file', async () => {
     .mockImplementation(() => {});
 
   render(<App />);
-  fireEvent.click(screen.getByRole('button', { name: /download state/i }));
+  fireEvent.click(screen.getByLabelText(/menu/i));
+  fireEvent.click(screen.getByRole('button', { name: /export state/i }));
 
   await waitFor(() => {
     expect(urlSpy).toHaveBeenCalled();

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -42,7 +42,9 @@ export default function App() {
       </button>
       {menuOpen && (
         <div className="menu">
-          <button onClick={exportState}>Export state</button>
+          <button className="menu-item" onClick={exportState}>
+            Export state
+          </button>
         </div>
       )}
       <h1>Todo Vibe</h1>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import './App.css';
 
 export default function App() {
+  const [menuOpen, setMenuOpen] = useState(false);
   async function createList() {
     const name = window.prompt('List name?') ?? 'New List';
     const id = crypto.randomUUID();
@@ -9,7 +11,7 @@ export default function App() {
     window.location.assign(`/lists/${id}`);
   }
 
-  function downloadState() {
+  function exportState() {
     const lists = [] as unknown[];
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
@@ -31,12 +33,23 @@ export default function App() {
 
   return (
     <main className="intro">
+      <button
+        className="menu-button"
+        aria-label="Menu"
+        onClick={() => setMenuOpen(!menuOpen)}
+      >
+        ☰
+      </button>
+      {menuOpen && (
+        <div className="menu">
+          <button onClick={exportState}>Export state</button>
+        </div>
+      )}
       <h1>Todo Vibe</h1>
       <p className="tagline">Organize your tasks with style</p>
       <button className="start-button" onClick={createList}>
         Start a new list
       </button>
-      <button onClick={downloadState}>Download state</button>
     </main>
   );
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,26 @@ export default function App() {
     window.location.assign(`/lists/${id}`);
   }
 
+  function downloadState() {
+    const lists = [] as unknown[];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key?.startsWith('list:')) {
+        const item = localStorage.getItem(key);
+        if (item) {
+          lists.push(JSON.parse(item));
+        }
+      }
+    }
+    const blob = new Blob([JSON.stringify(lists)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'todo-state.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
   return (
     <main className="intro">
       <h1>Todo Vibe</h1>
@@ -16,6 +36,7 @@ export default function App() {
       <button className="start-button" onClick={createList}>
         Start a new list
       </button>
+      <button onClick={downloadState}>Download state</button>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- allow exporting all `list:` entries from localStorage as a JSON file
- add test covering download behavior
- document download button in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfa526622083309bc2833d3e0c282e