### PR TITLE
feat(web): add feedback footer

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -14,6 +14,12 @@ test('renders intro layout', () => {
   ).toHaveClass('start-button');
 });
 
+test('invites feedback link', () => {
+  render(<App />);
+  const link = screen.getByRole('link', { name: /feedback/i });
+  expect(link).toHaveAttribute('href', expect.stringContaining('github.com'));
+});
+
 const originalLocation = window.location;
 const originalPrompt = window.prompt;
 const originalUUID = global.crypto.randomUUID;

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -20,6 +20,12 @@ test('invites feedback link', () => {
   expect(link).toHaveAttribute('href', expect.stringContaining('github.com'));
 });
 
+test('feedback footer stays fixed to bottom', () => {
+  render(<App />);
+  const footer = screen.getByRole('contentinfo');
+  expect(getComputedStyle(footer).position).toBe('fixed');
+});
+
 const originalLocation = window.location;
 const originalPrompt = window.prompt;
 const originalUUID = global.crypto.randomUUID;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import './App.css';
+import FeedbackFooter from './FeedbackFooter';
 
 export default function App() {
   const [menuOpen, setMenuOpen] = useState(false);
@@ -52,6 +53,7 @@ export default function App() {
       <button className="start-button" onClick={createList}>
         Start a new list
       </button>
+      <FeedbackFooter />
     </main>
   );
 }

--- a/web/src/FeedbackFooter.css
+++ b/web/src/FeedbackFooter.css
@@ -1,8 +1,10 @@
 .feedback-footer {
-  position: absolute;
+  position: fixed;
+  left: 0;
   bottom: 1rem;
   width: 100%;
   text-align: center;
+  z-index: 1000;
 }
 
 .feedback-footer a {

--- a/web/src/FeedbackFooter.css
+++ b/web/src/FeedbackFooter.css
@@ -1,0 +1,23 @@
+.feedback-footer {
+  position: absolute;
+  bottom: 1rem;
+  width: 100%;
+  text-align: center;
+}
+
+.feedback-footer a {
+  display: inline-block;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  text-decoration: none;
+  font-weight: 600;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.feedback-footer a:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}

--- a/web/src/FeedbackFooter.tsx
+++ b/web/src/FeedbackFooter.tsx
@@ -2,7 +2,10 @@ import './FeedbackFooter.css';
 
 export default function FeedbackFooter() {
   return (
-    <footer className="feedback-footer">
+    <footer
+      className="feedback-footer"
+      style={{ position: 'fixed', left: 0, bottom: '1rem', width: '100%', zIndex: 1000 }}
+    >
       <a
         href="https://github.com/bpetersen/todo-vibe/issues/new"
         target="_blank"

--- a/web/src/FeedbackFooter.tsx
+++ b/web/src/FeedbackFooter.tsx
@@ -1,0 +1,15 @@
+import './FeedbackFooter.css';
+
+export default function FeedbackFooter() {
+  return (
+    <footer className="feedback-footer">
+      <a
+        href="https://github.com/bpetersen/todo-vibe/issues/new"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        💬 Give Feedback
+      </a>
+    </footer>
+  );
+}

--- a/web/src/List.css
+++ b/web/src/List.css
@@ -16,6 +16,7 @@ body {
   font-family: 'Poppins', system-ui, sans-serif;
   background: linear-gradient(135deg, var(--bg-start), var(--bg-end));
   color: #333;
+  position: relative;
 }
 
 .list h1 {

--- a/web/src/List.test.tsx
+++ b/web/src/List.test.tsx
@@ -28,6 +28,20 @@ test('renders list name from local storage', async () => {
   expect(screen.getByPlaceholderText(/add a todo/i)).toBeInTheDocument();
 });
 
+test('invites feedback link', async () => {
+  localStorage.setItem(
+    'list:abc123',
+    JSON.stringify({ id: 'abc123', name: 'Groceries', todos: [] })
+  );
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, pathname: '/lists/abc123' },
+    writable: true,
+  });
+  render(<List />);
+  const link = await screen.findByRole('link', { name: /feedback/i });
+  expect(link).toHaveAttribute('href', expect.stringContaining('github.com'));
+});
+
 test('adds a new todo and displays it', async () => {
   localStorage.setItem(
     'list:abc123',

--- a/web/src/List.test.tsx
+++ b/web/src/List.test.tsx
@@ -42,6 +42,20 @@ test('invites feedback link', async () => {
   expect(link).toHaveAttribute('href', expect.stringContaining('github.com'));
 });
 
+test('feedback footer stays fixed to bottom', async () => {
+  localStorage.setItem(
+    'list:abc123',
+    JSON.stringify({ id: 'abc123', name: 'Groceries', todos: [] })
+  );
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, pathname: '/lists/abc123' },
+    writable: true,
+  });
+  render(<List />);
+  const footer = await screen.findByRole('contentinfo');
+  expect(getComputedStyle(footer).position).toBe('fixed');
+});
+
 test('adds a new todo and displays it', async () => {
   localStorage.setItem(
     'list:abc123',

--- a/web/src/List.tsx
+++ b/web/src/List.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from 'react';
 import './List.css';
+import FeedbackFooter from './FeedbackFooter';
 import { CreateTodo } from '../../src/domain/todo/CreateTodo';
 import { CompleteTodo } from '../../src/domain/todo/CompleteTodo';
 import { ReopenTodo } from '../../src/domain/todo/ReopenTodo';
@@ -140,6 +141,7 @@ export default function List() {
           </li>
         ))}
       </ul>
+      <FeedbackFooter />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add stylish feedback footer with link to GitHub issues on all pages
- cover footer with tests for App and List views

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfb46d26288330b3c8a5e2570d2d25