### PR TITLE
feat: add list manager for active lists

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -29,21 +29,27 @@ body {
   color: #555;
 }
 
-.start-button {
+.split-button {
   margin-top: 2rem;
+  display: flex;
+  border-radius: 9999px;
+  overflow: hidden;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
+}
+
+.split-button-half {
+  flex: 1;
   background: linear-gradient(135deg, var(--primary), var(--accent));
   color: #fff;
   padding: 0.75rem 1.5rem;
   border: none;
-  border-radius: 9999px;
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
   transition: transform 0.2s, box-shadow 0.2s;
 }
 
-.start-button:hover {
+.split-button-half:hover {
   transform: translateY(-2px);
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
 }

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -63,7 +63,13 @@ test('stores a new list in local storage with a name', async () => {
     expect(uuidMock).toHaveBeenCalled();
     expect(assignMock).toHaveBeenCalledWith('/lists/abc123');
     const saved = JSON.parse(localStorage.getItem('list:abc123')!);
-    expect(saved).toEqual({ id: 'abc123', name: 'Groceries', todos: [] });
+    expect(saved).toMatchObject({
+      id: 'abc123',
+      name: 'Groceries',
+      todos: [],
+      archived: false,
+    });
+    expect(saved.createdAt).toBeDefined();
   });
 });
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -9,15 +9,22 @@ test('renders intro layout', () => {
   expect(
     screen.getByText(/organize your tasks with style/i)
   ).toBeInTheDocument();
-  expect(
-    screen.getByRole('button', { name: /start a new list/i })
-  ).toHaveClass('start-button');
+  const newButton = screen.getByRole('button', { name: /new/i });
+  const continueButton = screen.getByRole('button', { name: /continue/i });
+  expect(newButton).toHaveClass('split-button-half');
+  expect(continueButton).toHaveClass('split-button-half');
 });
 
-test('links to list manager', () => {
+test('continue button navigates to list manager', () => {
+  const assignMock = vi.fn();
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, assign: assignMock },
+    writable: true,
+  });
   render(<App />);
-  const link = screen.getByRole('link', { name: /view lists/i });
-  expect(link).toHaveAttribute('href', '/lists');
+  const button = screen.getByRole('button', { name: /continue/i });
+  fireEvent.click(button);
+  expect(assignMock).toHaveBeenCalledWith('/lists');
 });
 
 test('invites feedback link', () => {
@@ -61,7 +68,7 @@ test('stores a new list in local storage with a name', async () => {
   });
 
   render(<App />);
-  const button = screen.getByRole('button', { name: /start a new list/i });
+  const button = screen.getByRole('button', { name: /new/i });
   fireEvent.click(button);
 
   await waitFor(() => {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -14,6 +14,12 @@ test('renders intro layout', () => {
   ).toHaveClass('start-button');
 });
 
+test('links to list manager', () => {
+  render(<App />);
+  const link = screen.getByRole('link', { name: /view lists/i });
+  expect(link).toHaveAttribute('href', '/lists');
+});
+
 test('invites feedback link', () => {
   render(<App />);
   const link = screen.getByRole('link', { name: /feedback/i });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,7 +7,13 @@ export default function App() {
   async function createList() {
     const name = window.prompt('List name?') ?? 'New List';
     const id = crypto.randomUUID();
-    const list = { id, name, todos: [] };
+    const list = {
+      id,
+      name,
+      todos: [],
+      createdAt: new Date().toISOString(),
+      archived: false,
+    };
     localStorage.setItem(`list:${id}`, JSON.stringify(list));
     window.location.assign(`/lists/${id}`);
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -56,10 +56,17 @@ export default function App() {
       )}
       <h1>Todo Vibe</h1>
       <p className="tagline">Organize your tasks with style</p>
-      <button className="start-button" onClick={createList}>
-        Start a new list
-      </button>
-      <a href="/lists">View lists</a>
+      <div className="split-button">
+        <button className="split-button-half" onClick={createList}>
+          New
+        </button>
+        <button
+          className="split-button-half"
+          onClick={() => window.location.assign('/lists')}
+        >
+          Continue
+        </button>
+      </div>
       <FeedbackFooter />
     </main>
   );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -59,6 +59,7 @@ export default function App() {
       <button className="start-button" onClick={createList}>
         Start a new list
       </button>
+      <a href="/lists">View lists</a>
       <FeedbackFooter />
     </main>
   );

--- a/web/src/List.tsx
+++ b/web/src/List.tsx
@@ -37,7 +37,9 @@ export default function List() {
     const events = CreateTodo({ todoId, title, createdAt: new Date() });
     const newTodo: Todo = { id: todoId, title, completed: false, events };
     const stored = localStorage.getItem(`list:${id}`);
-    const list = stored ? JSON.parse(stored) : { id, name, todos: [] };
+    const list = stored
+      ? JSON.parse(stored)
+      : { id, name, todos: [], createdAt: new Date().toISOString(), archived: false };
     list.todos.push(newTodo);
     localStorage.setItem(`list:${id}`, JSON.stringify(list));
     setTodos(t => [...t, newTodo]);
@@ -94,7 +96,9 @@ export default function List() {
       ...updated[dragIndex],
       events: [...(updated[dragIndex].events || []), ...events],
     };
-    const stored = { id, name, todos: updated };
+    const existing = localStorage.getItem(`list:${id}`);
+    const base = existing ? JSON.parse(existing) : {};
+    const stored = { ...base, id, name, todos: updated };
     localStorage.setItem(`list:${id}`, JSON.stringify(stored));
     setTodos(updated);
     setDragIndex(null);

--- a/web/src/ListManager.css
+++ b/web/src/ListManager.css
@@ -1,0 +1,91 @@
+.list-manager {
+  min-height: 100vh;
+  padding: 2rem;
+  font-family: 'Poppins', system-ui, sans-serif;
+  background: linear-gradient(135deg, var(--bg-start), var(--bg-end));
+  color: #333;
+}
+
+.list-manager h1 {
+  margin-bottom: 1rem;
+}
+
+.new-list-button {
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  color: #fff;
+  border: none;
+  border-radius: 9999px;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
+  transition: transform 0.2s, box-shadow 0.2s;
+  margin-bottom: 2rem;
+}
+
+.new-list-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+}
+
+.list-cards {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.list-card {
+  background: #fff;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s, box-shadow 0.2s;
+  display: flex;
+  flex-direction: column;
+}
+
+.list-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
+}
+
+.list-card a {
+  font-size: 1.25rem;
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--primary);
+}
+
+.counts {
+  margin-top: 0.5rem;
+  color: #555;
+}
+
+.actions {
+  margin-top: auto;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.actions button {
+  flex: 1;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.actions button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}

--- a/web/src/ListManager.test.tsx
+++ b/web/src/ListManager.test.tsx
@@ -49,10 +49,14 @@ test('lists active lists ordered by creation date with counts', async () => {
   );
 
   render(<ListManager />);
+  const list = await screen.findByRole('list');
+  expect(list).toHaveClass('list-cards');
   const items = await screen.findAllByRole('listitem');
   expect(items).toHaveLength(2);
+  expect(items[0]).toHaveClass('list-card');
   expect(items[0]).toHaveTextContent('First');
   expect(items[0]).toHaveTextContent('1/2');
+  expect(items[1]).toHaveClass('list-card');
   expect(items[1]).toHaveTextContent('Second');
   expect(items[1]).toHaveTextContent('1/1');
 });

--- a/web/src/ListManager.test.tsx
+++ b/web/src/ListManager.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi, afterEach } from 'vitest';
+import ListManager from './ListManager';
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+  window.prompt = originalPrompt;
+  window.confirm = originalConfirm;
+});
+
+const originalPrompt = window.prompt;
+const originalConfirm = window.confirm;
+
+test('lists active lists ordered by creation date with counts', async () => {
+  localStorage.setItem(
+    'list:one',
+    JSON.stringify({
+      id: 'one',
+      name: 'First',
+      createdAt: '2024-01-01T00:00:00Z',
+      todos: [
+        { completed: false },
+        { completed: true },
+      ],
+    }),
+  );
+  localStorage.setItem(
+    'list:two',
+    JSON.stringify({
+      id: 'two',
+      name: 'Second',
+      createdAt: '2024-01-02T00:00:00Z',
+      todos: [
+        { completed: true },
+      ],
+    }),
+  );
+  localStorage.setItem(
+    'list:arch',
+    JSON.stringify({
+      id: 'arch',
+      name: 'Archived',
+      createdAt: '2024-01-03T00:00:00Z',
+      todos: [],
+      archived: true,
+    }),
+  );
+
+  render(<ListManager />);
+  const items = await screen.findAllByRole('listitem');
+  expect(items).toHaveLength(2);
+  expect(items[0]).toHaveTextContent('First');
+  expect(items[0]).toHaveTextContent('1/2');
+  expect(items[1]).toHaveTextContent('Second');
+  expect(items[1]).toHaveTextContent('1/1');
+});
+
+test('creates a new list', async () => {
+  const uuidMock = vi
+    .spyOn(global.crypto, 'randomUUID')
+    .mockReturnValue('newid');
+  const promptMock = vi.fn().mockReturnValue('Chores');
+  window.prompt = promptMock as any;
+
+  render(<ListManager />);
+  fireEvent.click(screen.getByRole('button', { name: /new list/i }));
+
+  await waitFor(() => {
+    expect(promptMock).toHaveBeenCalled();
+    const saved = JSON.parse(localStorage.getItem('list:newid')!);
+    expect(saved).toMatchObject({ id: 'newid', name: 'Chores', todos: [], archived: false });
+    expect(saved.createdAt).toBeDefined();
+    expect(uuidMock).toHaveBeenCalled();
+  });
+  await screen.findByRole('link', { name: 'Chores' });
+});
+
+test('renames a list', async () => {
+  localStorage.setItem(
+    'list:abc',
+    JSON.stringify({ id: 'abc', name: 'Old', createdAt: '2024-01-01T00:00:00Z', todos: [] }),
+  );
+  const promptMock = vi.fn().mockReturnValue('New');
+  window.prompt = promptMock as any;
+
+  render(<ListManager />);
+  fireEvent.click(screen.getByRole('button', { name: /rename/i }));
+
+  await waitFor(() => {
+    const saved = JSON.parse(localStorage.getItem('list:abc')!);
+    expect(saved.name).toBe('New');
+  });
+  await screen.findByRole('link', { name: 'New' });
+});
+
+test('archives a list after confirmation', async () => {
+  localStorage.setItem(
+    'list:abc',
+    JSON.stringify({ id: 'abc', name: 'Old', createdAt: '2024-01-01T00:00:00Z', todos: [] }),
+  );
+  const confirmMock = vi.fn().mockReturnValue(true);
+  window.confirm = confirmMock as any;
+
+  render(<ListManager />);
+  fireEvent.click(screen.getByRole('button', { name: /archive/i }));
+
+  await waitFor(() => {
+    const saved = JSON.parse(localStorage.getItem('list:abc')!);
+    expect(saved.archived).toBe(true);
+    expect(confirmMock).toHaveBeenCalled();
+  });
+  expect(screen.queryByText('Old')).not.toBeInTheDocument();
+});

--- a/web/src/ListManager.tsx
+++ b/web/src/ListManager.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import './ListManager.css';
 
 interface List {
   id: string;
@@ -60,16 +61,23 @@ export default function ListManager() {
   return (
     <main className="list-manager">
       <h1>Your Lists</h1>
-      <button onClick={createList}>New list</button>
-      <ul>
+      <button className="new-list-button" onClick={createList}>
+        New list
+      </button>
+      <ul className="list-cards">
         {lists.map(list => {
           const completed = list.todos.filter(t => t.completed).length;
           const total = list.todos.length;
           return (
-            <li key={list.id}>
-              <a href={`/lists/${list.id}`}>{list.name}</a> <span>{completed}/{total}</span>
-              <button onClick={() => renameList(list.id)}>Rename</button>
-              <button onClick={() => archiveList(list.id)}>Archive</button>
+            <li key={list.id} className="list-card">
+              <a href={`/lists/${list.id}`}>{list.name}</a>
+              <span className="counts">
+                {completed}/{total}
+              </span>
+              <div className="actions">
+                <button onClick={() => renameList(list.id)}>Rename</button>
+                <button onClick={() => archiveList(list.id)}>Archive</button>
+              </div>
             </li>
           );
         })}

--- a/web/src/ListManager.tsx
+++ b/web/src/ListManager.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+
+interface List {
+  id: string;
+  name: string;
+  todos: { completed: boolean }[];
+  createdAt: string;
+  archived?: boolean;
+}
+
+export default function ListManager() {
+  const [lists, setLists] = useState<List[]>([]);
+
+  useEffect(() => {
+    const loaded: List[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key?.startsWith('list:')) {
+        const raw = localStorage.getItem(key);
+        if (raw) {
+          const list = JSON.parse(raw);
+          if (!list.archived) loaded.push(list);
+        }
+      }
+    }
+    loaded.sort(
+      (a, b) => new Date(a.createdAt || 0).getTime() - new Date(b.createdAt || 0).getTime(),
+    );
+    setLists(loaded);
+  }, []);
+
+  function createList() {
+    const name = window.prompt('List name?') ?? 'New List';
+    const id = crypto.randomUUID();
+    const createdAt = new Date().toISOString();
+    const list: List = { id, name, todos: [], createdAt, archived: false };
+    localStorage.setItem(`list:${id}`, JSON.stringify(list));
+    setLists(prev => [...prev, list].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()));
+  }
+
+  function renameList(id: string) {
+    const list = lists.find(l => l.id === id);
+    if (!list) return;
+    const name = window.prompt('New name?', list.name);
+    if (!name) return;
+    const updated = { ...list, name };
+    localStorage.setItem(`list:${id}`, JSON.stringify(updated));
+    setLists(prev => prev.map(l => (l.id === id ? updated : l)));
+  }
+
+  function archiveList(id: string) {
+    const list = lists.find(l => l.id === id);
+    if (!list) return;
+    if (!window.confirm('Archive this list?')) return;
+    const updated = { ...list, archived: true };
+    localStorage.setItem(`list:${id}`, JSON.stringify(updated));
+    setLists(prev => prev.filter(l => l.id !== id));
+  }
+
+  return (
+    <main className="list-manager">
+      <h1>Your Lists</h1>
+      <button onClick={createList}>New list</button>
+      <ul>
+        {lists.map(list => {
+          const completed = list.todos.filter(t => t.completed).length;
+          const total = list.todos.length;
+          return (
+            <li key={list.id}>
+              <a href={`/lists/${list.id}`}>{list.name}</a> <span>{completed}/{total}</span>
+              <button onClick={() => renameList(list.id)}>Rename</button>
+              <button onClick={() => archiveList(list.id)}>Archive</button>
+            </li>
+          );
+        })}
+      </ul>
+    </main>
+  );
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,9 +2,16 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import List from './List';
+import ListManager from './ListManager';
 
 const root = ReactDOM.createRoot(document.getElementById('root')!);
-const Component = window.location.pathname.startsWith('/lists/') ? List : App;
+const path = window.location.pathname;
+const Component =
+  path === '/lists'
+    ? ListManager
+    : path.startsWith('/lists/')
+      ? List
+      : App;
 
 root.render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- add ListManager component and /lists route for managing lists
- allow creating, renaming, and archiving lists with completion counts
- track list metadata when creating lists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfcaa5f83483309e91bf7233450ca0