### PR TITLE
Add breadcrumb navigation on list page

### DIFF
--- a/web/src/List.css
+++ b/web/src/List.css
@@ -23,6 +23,15 @@ body {
   margin-bottom: 1rem;
 }
 
+.breadcrumbs {
+  margin-bottom: 0.5rem;
+}
+
+.breadcrumbs a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
 .list input[type="text"] {
   width: 100%;
   padding: 0.75rem 1rem;

--- a/web/src/List.test.tsx
+++ b/web/src/List.test.tsx
@@ -28,6 +28,23 @@ test('renders list name from local storage', async () => {
   expect(screen.getByPlaceholderText(/add a todo/i)).toBeInTheDocument();
 });
 
+test('links back to all lists', async () => {
+  localStorage.setItem(
+    'list:abc123',
+    JSON.stringify({ id: 'abc123', name: 'Groceries', todos: [] })
+  );
+
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, pathname: '/lists/abc123' },
+    writable: true,
+  });
+
+  render(<List />);
+
+  const link = await screen.findByRole('link', { name: /all lists/i });
+  expect(link).toHaveAttribute('href', '/lists');
+});
+
 test('invites feedback link', async () => {
   localStorage.setItem(
     'list:abc123',

--- a/web/src/List.tsx
+++ b/web/src/List.tsx
@@ -107,6 +107,9 @@ export default function List() {
 
   return (
     <main className="list">
+      <nav aria-label="Breadcrumb" className="breadcrumbs">
+        <a href="/lists">All lists</a> / {name}
+      </nav>
       <h1>{name}</h1>
       <input
         type="text"


### PR DESCRIPTION
## Summary
- add breadcrumb navigation to list view linking back to all lists
- style breadcrumb link for visibility
- test that lists page link is present

## Testing
- `npm test >/tmp/unit.log 2>&1; tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68c3959f33f48330917ef022005c8c49